### PR TITLE
add: Gill examples to first half of Tokens section in Solana Cookbook

### DIFF
--- a/apps/web/content/cookbook/tokens/create-mint-account.mdx
+++ b/apps/web/content/cookbook/tokens/create-mint-account.mdx
@@ -13,6 +13,65 @@ The transaction to create a mint account needs two instructions:
 2. Invoke the Token Program to initialize the mint account data.
 
 <CodeTabs storage="cookbook" flags="r">
+```ts !! title="Gill"
+import { createTransaction, generateKeyPairSigner, type KeyPairSigner, createSolanaClient, getMinimumBalanceForRentExemption, getExplorerLink, getSignatureFromTransaction, signTransactionMessageWithSigners } from "gill";
+import { loadKeypairSignerFromFile } from "gill/node";
+import { TOKEN_2022_PROGRAM_ADDRESS, getCreateAccountInstruction, getCreateMetadataAccountV3Instruction, getInitializeMintInstruction, getMintSize } from "gill/programs";
+
+const { rpc, sendAndConfirmTransaction } = createSolanaClient({
+    urlOrMoniker: "localnet",
+});
+
+// This defaults to the file path used by the Solana CLI: `~/.config/solana/id.json`
+const signer: KeyPairSigner = await loadKeypairSignerFromFile();
+console.log("signer:", signer.address);
+
+const tokenProgram = TOKEN_2022_PROGRAM_ADDRESS;
+
+const mint = await generateKeyPairSigner();
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+const space = getMintSize();
+
+const transaction = createTransaction({
+    feePayer: signer,
+    version: "legacy",
+    instructions: [
+        getCreateAccountInstruction({
+            space,
+            lamports: getMinimumBalanceForRentExemption(space),
+            newAccount: mint,
+            payer: signer,
+            programAddress: tokenProgram,
+        }),
+        getInitializeMintInstruction(
+            {
+                mint: mint.address,
+                mintAuthority: signer.address,
+                freezeAuthority: signer.address,
+                decimals: 9,
+            },
+            {
+                programAddress: tokenProgram,
+            },
+        ),
+
+    ],
+    latestBlockhash,
+});
+
+const signedTransaction = await signTransactionMessageWithSigners(transaction);
+
+console.log(
+    "Explorer:",
+    getExplorerLink({
+        cluster: "localnet",
+        transaction: getSignatureFromTransaction(signedTransaction),
+    }),
+);
+
+await sendAndConfirmTransaction(signedTransaction);
+```
 
 ```ts !! title="Kit"
 import {
@@ -94,6 +153,7 @@ const transactionSignature = getSignatureFromTransaction(signedTransaction);
 console.log("Mint Address:", mint.address);
 console.log("Transaction Signature:", transactionSignature);
 ```
+
 
 ```ts !! title="Legacy"
 import {

--- a/apps/web/content/cookbook/tokens/create-token-account.mdx
+++ b/apps/web/content/cookbook/tokens/create-token-account.mdx
@@ -16,6 +16,110 @@ units of a specific token (mint).
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import { createTransaction, generateKeyPairSigner, createSolanaClient, getExplorerLink, getSignatureFromTransaction, signTransactionMessageWithSigners, airdropFactory, createSolanaRpcSubscriptions, lamports } from "gill";
+import { TOKEN_2022_PROGRAM_ADDRESS, getAssociatedTokenAccountAddress, getCreateAccountInstruction, getInitializeMintInstruction, getMintSize } from "gill/programs";
+import { getCreateAssociatedTokenInstruction } from "gill/programs";
+
+const { rpc, sendAndConfirmTransaction } = createSolanaClient({
+    urlOrMoniker: "localnet",
+});
+const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
+
+const feePayer = await generateKeyPairSigner();
+
+await airdropFactory({ rpc, rpcSubscriptions })({
+    recipientAddress: feePayer.address,
+    lamports: lamports(1_000_000_000n),
+    commitment: "confirmed"
+});
+
+
+const mint = await generateKeyPairSigner();
+
+const space = BigInt(getMintSize());
+
+const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+
+const transaction = createTransaction({
+    feePayer: feePayer,
+    version: "legacy",
+    instructions: [
+        getCreateAccountInstruction({
+            payer: feePayer,
+            newAccount: mint,
+            lamports: rent,
+            space,
+            programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+        }),
+        getInitializeMintInstruction(
+            {
+                mint: mint.address,
+                decimals: 2,
+                mintAuthority: feePayer.address,
+            },
+            {
+                programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+            },
+        ),
+
+    ],
+    latestBlockhash,
+});
+
+const signedTransaction = await signTransactionMessageWithSigners(transaction);
+
+console.log(
+    "Explorer:",
+    getExplorerLink({
+        cluster: "localnet",
+        transaction: getSignatureFromTransaction(signedTransaction),
+    }),
+);
+
+await sendAndConfirmTransaction(signedTransaction);
+console.log("Mint Address: ", mint.address.toString());
+
+
+// !mark
+const associatedTokenAddress = await getAssociatedTokenAccountAddress(mint.address, feePayer.address, TOKEN_2022_PROGRAM_ADDRESS);
+
+
+console.log(
+    "Associated Token Account Address: ",
+    associatedTokenAddress.toString()
+);
+
+
+const { value: latestBlockhash2 } = await rpc.getLatestBlockhash().send();
+
+// !mark(1:7)
+const createAtaInstruction = await getCreateAssociatedTokenInstruction({
+    payer: feePayer,
+    mint: mint.address,
+    owner: feePayer.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    ata: associatedTokenAddress,
+});
+
+const transaction2 = createTransaction({
+    feePayer: feePayer,
+    version: "legacy",
+    instructions: [
+        createAtaInstruction,
+    ],
+    latestBlockhash: latestBlockhash2,
+});
+
+const signedTransaction2 = await signTransactionMessageWithSigners(transaction2);
+
+await sendAndConfirmTransaction(signedTransaction2);
+
+```
+
 ```ts !! title="Kit"
 import {
   airdropFactory,

--- a/apps/web/content/cookbook/tokens/get-token-account.mdx
+++ b/apps/web/content/cookbook/tokens/get-token-account.mdx
@@ -10,6 +10,28 @@ amount(balance).
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import { createSolanaClient, address } from "gill";
+import { TOKEN_2022_PROGRAM_ADDRESS, fetchToken, getAssociatedTokenAccountAddress } from "gill/programs";
+
+
+const { rpc } = createSolanaClient({
+    urlOrMoniker: "mainnet",
+});
+
+const mintAddresss = address("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo");
+
+const authority = address("AC5RDfQFmDS1deWZos921JfqscXdByf8BKHs5ACWjtW2");
+
+const associatedTokenAddress = await getAssociatedTokenAccountAddress(mintAddresss, authority, TOKEN_2022_PROGRAM_ADDRESS);
+
+// !mark
+const ataDetails = await fetchToken(rpc, associatedTokenAddress);
+
+console.log(ataDetails);
+
+```
+
 ```ts !! title="Kit"
 import {
   fetchToken,

--- a/apps/web/content/cookbook/tokens/get-token-balance.mdx
+++ b/apps/web/content/cookbook/tokens/get-token-balance.mdx
@@ -9,6 +9,20 @@ The token account holds the token balance, which can be retrieved with a single
 PRC call
 
 <CodeTabs storage="cookbook" flags="r">
+```ts !! title="Gill"
+import { createSolanaClient, address } from "gill";
+
+const { rpc } = createSolanaClient({
+    urlOrMoniker: "mainnet",
+});
+
+const tokenAccountAddress = address("GfVPzUxMDvhFJ1Xs6C9i47XQRSapTd8LHw5grGuTquyQ");
+
+// !mark
+const balance = await rpc.getTokenAccountBalance(tokenAccountAddress).send();
+
+console.log(balance);
+```
 
 ```typescript !! title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
@@ -83,10 +97,10 @@ from solders.pubkey import Pubkey
 
 async def main():
     rpc = AsyncClient("https://api.mainnet-beta.solana.com")
-    
+
     # Use a real token account address from mainnet
     token_account_address = Pubkey.from_string("GfVPzUxMDvhFJ1Xs6C9i47XQRSapTd8LHw5grGuTquyQ")
-    
+
     async with rpc:
         try:
             balance = await rpc.get_token_account_balance(token_account_address)

--- a/apps/web/content/cookbook/tokens/get-token-mint.mdx
+++ b/apps/web/content/cookbook/tokens/get-token-mint.mdx
@@ -10,6 +10,23 @@ need to get the account info for the token mint.
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import { address, createSolanaClient, KeyPairSigner } from "gill";
+import { fetchMint } from "gill/programs";
+
+const { rpc } = createSolanaClient({
+    urlOrMoniker: "mainnet",
+});
+
+const mintAddress = address("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo")
+
+// !mark
+const mint = await fetchMint(rpc, mintAddress);
+
+console.log(mint);
+
+```
+
 ```ts !! title="Kit"
 import { Address, createSolanaRpc } from "@solana/kit";
 import { fetchMint } from "@solana-program/token-2022";

--- a/apps/web/content/cookbook/tokens/mint-tokens.mdx
+++ b/apps/web/content/cookbook/tokens/mint-tokens.mdx
@@ -10,6 +10,113 @@ specific token account.
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import { address, airdropFactory, createSolanaClient, createSolanaRpcSubscriptions, createTransaction, generateKeyPairSigner, getExplorerLink, getSignatureFromTransaction, lamports, signTransactionMessageWithSigners } from "gill";
+import { } from "gill/node";
+import { getCreateAccountInstruction, getCreateAssociatedTokenInstruction, getInitializeMintInstruction, getMintSize, getMintToCheckedInstruction, TOKEN_2022_PROGRAM_ADDRESS } from "gill/programs";
+
+
+const { rpc, sendAndConfirmTransaction } = createSolanaClient({
+    urlOrMoniker: "localnet",
+});
+const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+const DECIMALS = 9;
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+let { mint, associatedTokenAddress } = await setup();
+
+const transaction = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions: [
+        // !mark(1:7)
+        getMintToCheckedInstruction({
+            mint,
+            token: associatedTokenAddress,
+            mintAuthority: MINT_AUTHORITY,
+            amount: 1_000_000_000n,
+            decimals: DECIMALS
+        })
+    ],
+    latestBlockhash,
+});
+const signedTransaction = await signTransactionMessageWithSigners(transaction);
+
+console.log(
+    "Explorer:",
+    getExplorerLink({
+        cluster: "localnet",
+        transaction: getSignatureFromTransaction(signedTransaction),
+    }),
+);
+
+await sendAndConfirmTransaction(signedTransaction);
+
+
+async function setup() {
+    await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+    });
+
+
+    const mint = await generateKeyPairSigner();
+
+    const space = BigInt(getMintSize());
+
+    const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+    const transaction = createTransaction({
+        feePayer: MINT_AUTHORITY,
+        version: "legacy",
+        instructions: [
+            getCreateAccountInstruction({
+                payer: MINT_AUTHORITY,
+                newAccount: mint,
+                lamports: rent,
+                space,
+                programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+            }),
+            getInitializeMintInstruction(
+                {
+                    mint: mint.address,
+                    decimals: 2,
+                    mintAuthority: MINT_AUTHORITY.address,
+                },
+                {
+                    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+                },
+            ),
+            getCreateAssociatedTokenInstruction({
+                payer: MINT_AUTHORITY,
+                mint: mint.address,
+                owner: MINT_AUTHORITY.address,
+                tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+                ata: associatedTokenAddress,
+            }),
+
+
+        ],
+        latestBlockhash,
+    });
+
+
+    const signedTransaction = await signTransactionMessageWithSigners(transaction);
+
+    await sendAndConfirmTransaction(signedTransaction);
+
+    return {
+        mint: mint.address,
+        associatedTokenAddress
+    };
+
+}
+
+```
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {

--- a/apps/web/content/cookbook/tokens/transfer-tokens.mdx
+++ b/apps/web/content/cookbook/tokens/transfer-tokens.mdx
@@ -18,6 +18,147 @@ following examples:
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import { address, airdropFactory, createSolanaClient, createSolanaRpcSubscriptions, createTransaction, generateKeyPairSigner, getExplorerLink, getSignatureFromTransaction, lamports, signTransactionMessageWithSigners } from "gill";
+import { getAssociatedTokenAccountAddress, getCreateAccountInstruction, getCreateAssociatedTokenInstruction, getInitializeMintInstruction, getMintSize, getMintToCheckedInstruction, getTransferCheckedInstruction, TOKEN_2022_PROGRAM_ADDRESS } from "gill/programs";
+
+
+const { rpc, sendAndConfirmTransaction } = createSolanaClient({
+    urlOrMoniker: "localnet",
+});
+const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
+
+/* constants */
+const MINT_AUTHORITY = await generateKeyPairSigner();
+const RECEIVER = await generateKeyPairSigner();
+const DECIMALS = 9;
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+let { mint, authorityATA } = await setup();
+
+const receiverATA = await getAssociatedTokenAccountAddress(mint, RECEIVER.address, TOKEN_2022_PROGRAM_ADDRESS);
+
+
+const transaction = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions: [
+        // !mark(1:8)
+        getTransferCheckedInstruction({
+            source: authorityATA,
+            mint,
+            destination: receiverATA,
+            authority: MINT_AUTHORITY.address,
+            amount: 10_000_000_000n, // 10 tokens
+            decimals: DECIMALS
+        }),
+    ],
+    latestBlockhash,
+});
+const signedTransaction = await signTransactionMessageWithSigners(transaction);
+
+console.log(
+    "Explorer:",
+    getExplorerLink({
+        cluster: "localnet",
+        transaction: getSignatureFromTransaction(signedTransaction),
+    }),
+);
+
+await sendAndConfirmTransaction(signedTransaction);
+
+
+async function setup() {
+    await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+    });
+
+
+    const mint = await generateKeyPairSigner();
+
+    const space = BigInt(getMintSize());
+
+    const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+
+    const createAccountInstruction = getCreateAccountInstruction({
+        payer: MINT_AUTHORITY,
+        newAccount: mint,
+        lamports: rent,
+        space,
+        programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+    });
+
+    const initializeMintInstruction = getInitializeMintInstruction(
+        {
+            mint: mint.address,
+            decimals: DECIMALS,
+            mintAuthority: MINT_AUTHORITY.address,
+        },
+        {
+            programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+        },
+    );
+
+    const authorityATA = await getAssociatedTokenAccountAddress(mint.address, MINT_AUTHORITY.address, TOKEN_2022_PROGRAM_ADDRESS);
+
+    const receiverATA = await getAssociatedTokenAccountAddress(mint, RECEIVER.address, TOKEN_2022_PROGRAM_ADDRESS);
+
+
+    const crateAuthorityATAInstruction = getCreateAssociatedTokenInstruction({
+        payer: MINT_AUTHORITY,
+        ata: authorityATA,
+        owner: MINT_AUTHORITY.address,
+        mint: mint.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    })
+
+    const createReceiverATAInstruction = getCreateAssociatedTokenInstruction({
+        payer: MINT_AUTHORITY,
+        ata: receiverATA,
+        owner: RECEIVER.address,
+        mint: mint.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    })
+
+    const mintToInstruction = getMintToCheckedInstruction({
+        mint: mint.address,
+        token: authorityATA,
+        mintAuthority: MINT_AUTHORITY,
+        amount: 1_000_000_000_000n, // 1000
+        decimals: DECIMALS
+    });
+
+
+    const transaction = createTransaction({
+        feePayer: MINT_AUTHORITY,
+        version: "legacy",
+        instructions: [
+            createAccountInstruction,
+            initializeMintInstruction,
+            crateAuthorityATAInstruction,
+            createReceiverATAInstruction,
+            mintToInstruction
+        ],
+        latestBlockhash,
+    });
+
+
+    const signedTransaction = await signTransactionMessageWithSigners(transaction);
+
+    await sendAndConfirmTransaction(signedTransaction);
+
+    return {
+        mint: mint.address,
+        authorityATA
+    };
+
+}
+
+```
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {


### PR DESCRIPTION
### Problem
The Tokens section of the Solana Cookbook only had examples in Kit/legacy style, making it inconsistent with the newer Gill SDK and harder for developers adopting Gill to follow along.

### Summary of Changes
- Added Gill equivalents to the first half of the Tokens section in the Solana Cookbook.

- Ensured examples are consistent with Gill patterns and align with existing Kit examples for easier comparison.

- Improved clarity by showing how to achieve the same tasks (e.g., fetching mint data, creating tokens, using ATAs) with Gill.
