### PR TITLE
Add Gill tokens Second half examples to cookbook

### DIFF
--- a/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
@@ -20,7 +20,8 @@ import {
   signTransactionMessageWithSigners,
   getExplorerLink,
   getSignatureFromTransaction,
-  generateKeyPairSigner
+  generateKeyPairSigner,
+  airdropFactory
 } from "gill";
 import {
   getMintSize,
@@ -30,16 +31,19 @@ import {
   getAssociatedTokenAccountAddress,
   getCreateAssociatedTokenInstructionAsync,
   getMintToCheckedInstruction,
-  getApproveCheckedInstruction,
+  getApproveCheckedInstruction
 } from "gill/programs";
 
-const { rpc, rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
-  urlOrMoniker: "localnet",
-});
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "localnet"
+  }
+);
 
 const MINT_AUTHORITY = await generateKeyPairSigner();
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 const DELEGATE = await generateKeyPairSigner();
+const DECIMALS = 9;
 
 let { mint, authorityATA } = await setup();
 
@@ -49,14 +53,14 @@ const delegateInstruction = getApproveCheckedInstruction({
   delegate: DELEGATE.address,
   owner: MINT_AUTHORITY,
   amount: 1_000_000_000n, // 1 token
-  decimals: 9,
+  decimals: DECIMALS
 });
 
 const tx = createTransaction({
-    feePayer:MINT_AUTHORITY,
-    version:'legacy',
-    instructions:[delegateInstruction],
-    latestBlockhash
+  feePayer: MINT_AUTHORITY,
+  version: "legacy",
+  instructions: [delegateInstruction],
+  latestBlockhash
 });
 
 const signedTx = await signTransactionMessageWithSigners(tx);
@@ -64,19 +68,19 @@ const signedTx = await signTransactionMessageWithSigners(tx);
 const txSignature = getSignatureFromTransaction(signedTx);
 console.log("Transaction Signature:", txSignature);
 
-await sendAndConfirmTransaction(signedTx)
-
+await sendAndConfirmTransaction(signedTx);
 
 /*
  * The setup function initializes the mint and associated token accounts,
+ * and mints tokens to said associated token account
  *
  */
 async function setup() {
-   await airdropFactory({ rpc, rpcSubscriptions })({
-        recipientAddress: MINT_AUTHORITY.address,
-        lamports: lamports(1_000_000_000n),
-        commitment: "confirmed"
-    });
+  await airdropFactory({ rpc, rpcSubscriptions })({
+    recipientAddress: MINT_AUTHORITY.address,
+    lamports: lamports(1_000_000_000n),
+    commitment: "confirmed"
+  });
 
   const mint = await generateKeyPairSigner();
 
@@ -90,27 +94,27 @@ async function setup() {
     newAccount: mint,
     lamports: rent,
     space,
-    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS
   });
 
   const initializeMintInstruction = getInitializeMintInstruction({
     mint: mint.address,
-    decimals: 9,
-    mintAuthority: MINT_AUTHORITY.address,
+    decimals: DECIMALS,
+    mintAuthority: MINT_AUTHORITY.address
   });
 
   // create token account
   const authorityATA = await getAssociatedTokenAccountAddress(
-     mint.address,
-     MINT_AUTHORITY.address,
-    TOKEN_2022_PROGRAM_ADDRESS,
+    mint.address,
+    MINT_AUTHORITY.address,
+    TOKEN_2022_PROGRAM_ADDRESS
   );
 
   const createAuthorityATAInstruction =
     await getCreateAssociatedTokenInstructionAsync({
       payer: MINT_AUTHORITY,
       mint: mint.address,
-      owner: MINT_AUTHORITY.address,
+      owner: MINT_AUTHORITY.address
     });
 
   // mintTo token account
@@ -119,21 +123,21 @@ async function setup() {
     token: authorityATA,
     mintAuthority: MINT_AUTHORITY,
     amount: 1_000_000_000_000n, // 1000
-    decimals: 9,
+    decimals: DECIMALS
   });
 
   const instructions = [
     createAccountInstruction,
     initializeMintInstruction,
     createAuthorityATAInstruction,
-    mintToInstruction,
+    mintToInstruction
   ];
 
   const tx = createTransaction({
     feePayer: MINT_AUTHORITY,
     version: "legacy",
     instructions,
-    latestBlockhash,
+    latestBlockhash
   });
 
   const signedTx = await signTransactionMessageWithSigners(tx);
@@ -145,11 +149,10 @@ async function setup() {
 
   return {
     mint: mint.address,
-    authorityATA,
+    authorityATA
   };
 }
 ```
-
 
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";

--- a/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
@@ -27,7 +27,7 @@ import {
   getCreateAccountInstruction,
   TOKEN_2022_PROGRAM_ADDRESS,
   getInitializeMintInstruction,
-  findAssociatedTokenPda,
+  getAssociatedTokenAccountAddress,
   getCreateAssociatedTokenInstructionAsync,
   getMintToCheckedInstruction,
   getApproveCheckedInstruction,
@@ -61,12 +61,8 @@ const tx = createTransaction({
 
 const signedTx = await signTransactionMessageWithSigners(tx);
 
-console.log(
-  `Explorer ${getExplorerLink({
-    cluster: "devnet",
-    transaction: getSignatureFromTransaction(signedTx),
-  })}`
-);
+const txSignature = getSignatureFromTransaction(signedTx);
+console.log("Transaction Signature:", txSignature);
 
 await sendAndConfirmTransaction(signedTx)
 
@@ -104,11 +100,11 @@ async function setup() {
   });
 
   // create token account
-  const [authorityATA] = await findAssociatedTokenPda({
-    mint: mint.address,
-    owner: MINT_AUTHORITY.address,
-    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-  });
+  const authorityATA = await getAssociatedTokenAccountAddress(
+     mint.address,
+     MINT_AUTHORITY.address,
+    TOKEN_2022_PROGRAM_ADDRESS,
+  );
 
   const createAuthorityATAInstruction =
     await getCreateAssociatedTokenInstructionAsync({
@@ -142,12 +138,8 @@ async function setup() {
 
   const signedTx = await signTransactionMessageWithSigners(tx);
 
-  console.log(
-    `Explorer ${getExplorerLink({
-      cluster: "devnet",
-      transaction: getSignatureFromTransaction(signedTx),
-    })}`
-  );
+  const txSignature = getSignatureFromTransaction(signedTx);
+  console.log("Transaction Signature:", txSignature);
 
   await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
@@ -21,7 +21,8 @@ import {
   getExplorerLink,
   getSignatureFromTransaction,
   generateKeyPairSigner,
-  airdropFactory
+  airdropFactory,
+  lamports
 } from "gill";
 import {
   getMintSize,

--- a/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
@@ -14,25 +14,24 @@ is like an another owner of your token account.
 
 ```ts !! title="Gill"
 import {
+  airdropFactory,
   createSolanaClient,
-  generateKeyPairSigner,
   createTransaction,
-  signTransactionMessageWithSigners,
+  generateKeyPairSigner,
   getExplorerLink,
   getSignatureFromTransaction,
-  generateKeyPairSigner,
-  airdropFactory,
-  lamports
+  lamports,
+  signTransactionMessageWithSigners,
 } from "gill";
 import {
-  getMintSize,
-  getCreateAccountInstruction,
-  TOKEN_2022_PROGRAM_ADDRESS,
-  getInitializeMintInstruction,
+  getApproveCheckedInstruction,
   getAssociatedTokenAccountAddress,
+  getCreateAccountInstruction,
   getCreateAssociatedTokenInstructionAsync,
+  getInitializeMintInstruction,
+  getMintSize,
   getMintToCheckedInstruction,
-  getApproveCheckedInstruction
+  TOKEN_2022_PROGRAM_ADDRESS,
 } from "gill/programs";
 
 const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
@@ -144,7 +143,6 @@ async function setup() {
   const signedTx = await signTransactionMessageWithSigners(tx);
 
   const txSignature = getSignatureFromTransaction(signedTx);
-  console.log("Transaction Signature:", txSignature);
 
   await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
@@ -12,6 +12,153 @@ is like an another owner of your token account.
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  generateKeyPairSigner,
+  createTransaction,
+  signTransactionMessageWithSigners,
+  getExplorerLink,
+  getSignatureFromTransaction,
+  generateKeyPairSigner
+} from "gill";
+import {
+  getMintSize,
+  getCreateAccountInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getInitializeMintInstruction,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  getMintToCheckedInstruction,
+  getApproveCheckedInstruction,
+} from "gill/programs";
+
+const { rpc, rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "localnet",
+});
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const DELEGATE = await generateKeyPairSigner();
+
+let { mint, authorityATA } = await setup();
+
+const delegateInstruction = getApproveCheckedInstruction({
+  source: authorityATA,
+  mint,
+  delegate: DELEGATE.address,
+  owner: MINT_AUTHORITY,
+  amount: 1_000_000_000n, // 1 token
+  decimals: 9,
+});
+
+const tx = createTransaction({
+    feePayer:MINT_AUTHORITY,
+    version:'legacy',
+    instructions:[delegateInstruction],
+    latestBlockhash
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx)
+
+
+/*
+ * The setup function initializes the mint and associated token accounts,
+ *
+ */
+async function setup() {
+   await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+    });
+
+  const mint = await generateKeyPairSigner();
+
+  const space = BigInt(getMintSize());
+
+  const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+  // create & initialize mint account
+  const createAccountInstruction = getCreateAccountInstruction({
+    payer: MINT_AUTHORITY,
+    newAccount: mint,
+    lamports: rent,
+    space,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const initializeMintInstruction = getInitializeMintInstruction({
+    mint: mint.address,
+    decimals: 9,
+    mintAuthority: MINT_AUTHORITY.address,
+  });
+
+  // create token account
+  const [authorityATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: MINT_AUTHORITY.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const createAuthorityATAInstruction =
+    await getCreateAssociatedTokenInstructionAsync({
+      payer: MINT_AUTHORITY,
+      mint: mint.address,
+      owner: MINT_AUTHORITY.address,
+    });
+
+  // mintTo token account
+  const mintToInstruction = await getMintToCheckedInstruction({
+    mint: mint.address,
+    token: authorityATA,
+    mintAuthority: MINT_AUTHORITY,
+    amount: 1_000_000_000_000n, // 1000
+    decimals: 9,
+  });
+
+  const instructions = [
+    createAccountInstruction,
+    initializeMintInstruction,
+    createAuthorityATAInstruction,
+    mintToInstruction,
+  ];
+
+  const tx = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions,
+    latestBlockhash,
+  });
+
+  const signedTx = await signTransactionMessageWithSigners(tx);
+
+  console.log(
+    `Explorer ${getExplorerLink({
+      cluster: "devnet",
+      transaction: getSignatureFromTransaction(signedTx),
+    })}`
+  );
+
+  await sendAndConfirmTransaction(signedTx);
+
+  return {
+    mint: mint.address,
+    authorityATA,
+  };
+}
+```
+
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {

--- a/apps/web/content/cookbook/tokens/burn-tokens.mdx
+++ b/apps/web/content/cookbook/tokens/burn-tokens.mdx
@@ -9,24 +9,24 @@ You can burn tokens if you are the token account authority.
 
 ```ts !! title="Gill"
 import {
+  airdropFactory,
   createSolanaClient,
-  generateKeyPairSigner,
   createTransaction,
-  signTransactionMessageWithSigners,
+  generateKeyPairSigner,
   getExplorerLink,
   getSignatureFromTransaction,
-  airdropFactory,
-  lamports
+  lamports,
+  signTransactionMessageWithSigners,
 } from "gill";
 import {
-  getMintSize,
-  getCreateAccountInstruction,
-  TOKEN_2022_PROGRAM_ADDRESS,
-  getInitializeMintInstruction,
-  getCreateAssociatedTokenInstructionAsync,
-  getMintToCheckedInstruction,
   getBurnCheckedInstruction,
-  getAssociatedTokenAccountAddress
+  getCreateAccountInstruction,
+  getCreateAssociatedTokenInstructionAsync,
+  getInitializeMintInstruction,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getAssociatedTokenAccountAddress,
+  TOKEN_2022_PROGRAM_ADDRESS,
 } from "gill/programs";
 
 const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
@@ -136,7 +136,6 @@ async function setup() {
   const signedTx = await signTransactionMessageWithSigners(tx);
 
   const txSignature = getSignatureFromTransaction(signedTx);
-  console.log("Transaction Signature:", txSignature);
 
   await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/burn-tokens.mdx
+++ b/apps/web/content/cookbook/tokens/burn-tokens.mdx
@@ -15,6 +15,7 @@ import {
   signTransactionMessageWithSigners,
   getExplorerLink,
   getSignatureFromTransaction,
+  airdropFactory
 } from "gill";
 import {
   getMintSize,
@@ -27,12 +28,15 @@ import {
   getAssociatedTokenAccountAddress
 } from "gill/programs";
 
-const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
-  urlOrMoniker: "localnet",
-});
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "localnet"
+  }
+);
 
 const MINT_AUTHORITY = await generateKeyPairSigner();
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const DECIMALS = 9;
 
 let { mint, authorityATA } = await setup();
 
@@ -41,15 +45,14 @@ const burnTokenIx = getBurnCheckedInstruction({
   mint: mint,
   authority: MINT_AUTHORITY,
   amount: 100_000_000_000n, // 100 tokens
-  decimals: 9,
+  decimals: DECIMALS
 });
-
 
 const tx = createTransaction({
   feePayer: MINT_AUTHORITY,
   version: "legacy",
   instructions: [burnTokenIx],
-  latestBlockhash,
+  latestBlockhash
 });
 
 const signedTx = await signTransactionMessageWithSigners(tx);
@@ -61,16 +64,15 @@ await sendAndConfirmTransaction(signedTx);
 
 /*
  * The setup function initializes the mint and associated token accounts,
+ * and mints tokens to said associated token account
  *
  */
-
 async function setup() {
-
-   await airdropFactory({ rpc, rpcSubscriptions })({
-        recipientAddress: MINT_AUTHORITY.address,
-        lamports: lamports(1_000_000_000n),
-        commitment: "confirmed"
-    });
+  await airdropFactory({ rpc, rpcSubscriptions })({
+    recipientAddress: MINT_AUTHORITY.address,
+    lamports: lamports(1_000_000_000n),
+    commitment: "confirmed"
+  });
 
   const mint = await generateKeyPairSigner();
 
@@ -84,27 +86,27 @@ async function setup() {
     newAccount: mint,
     lamports: rent,
     space,
-    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS
   });
 
   const initializeMintInstruction = getInitializeMintInstruction({
     mint: mint.address,
-    decimals: 9,
-    mintAuthority: MINT_AUTHORITY.address,
+    decimals: DECIMALS,
+    mintAuthority: MINT_AUTHORITY.address
   });
 
-   // create token account
+  // create token account
   const authorityATA = await getAssociatedTokenAccountAddress(
-     mint.address,
-     MINT_AUTHORITY.address,
-    TOKEN_2022_PROGRAM_ADDRESS,
+    mint.address,
+    MINT_AUTHORITY.address,
+    TOKEN_2022_PROGRAM_ADDRESS
   );
 
   const createAuthorityATAInstruction =
     await getCreateAssociatedTokenInstructionAsync({
       payer: MINT_AUTHORITY,
       mint: mint.address,
-      owner: MINT_AUTHORITY.address,
+      owner: MINT_AUTHORITY.address
     });
 
   // mintTo token account
@@ -113,21 +115,21 @@ async function setup() {
     token: authorityATA,
     mintAuthority: MINT_AUTHORITY,
     amount: 1_000_000_000_000n, // 1000
-    decimals: 9,
+    decimals: DECIMALS
   });
 
   const instructions = [
     createAccountInstruction,
     initializeMintInstruction,
     createAuthorityATAInstruction,
-    mintToInstruction,
+    mintToInstruction
   ];
 
   const tx = createTransaction({
     feePayer: MINT_AUTHORITY,
     version: "legacy",
     instructions,
-    latestBlockhash,
+    latestBlockhash
   });
 
   const signedTx = await signTransactionMessageWithSigners(tx);
@@ -139,7 +141,7 @@ async function setup() {
 
   return {
     mint: mint.address,
-    authorityATA,
+    authorityATA
   };
 }
 ```

--- a/apps/web/content/cookbook/tokens/burn-tokens.mdx
+++ b/apps/web/content/cookbook/tokens/burn-tokens.mdx
@@ -21,10 +21,10 @@ import {
   getCreateAccountInstruction,
   TOKEN_2022_PROGRAM_ADDRESS,
   getInitializeMintInstruction,
-  findAssociatedTokenPda,
   getCreateAssociatedTokenInstructionAsync,
   getMintToCheckedInstruction,
   getBurnCheckedInstruction,
+  getAssociatedTokenAccountAddress
 } from "gill/programs";
 
 const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
@@ -54,12 +54,8 @@ const tx = createTransaction({
 
 const signedTx = await signTransactionMessageWithSigners(tx);
 
-console.log(
-  `Explorer ${getExplorerLink({
-    cluster: "devnet",
-    transaction: getSignatureFromTransaction(signedTx),
-  })}`
-);
+const txSignature = getSignatureFromTransaction(signedTx);
+console.log("Transaction Signature:", txSignature);
 
 await sendAndConfirmTransaction(signedTx);
 
@@ -97,12 +93,12 @@ async function setup() {
     mintAuthority: MINT_AUTHORITY.address,
   });
 
-  // create token account
-  const [authorityATA] = await findAssociatedTokenPda({
-    mint: mint.address,
-    owner: MINT_AUTHORITY.address,
-    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-  });
+   // create token account
+  const authorityATA = await getAssociatedTokenAccountAddress(
+     mint.address,
+     MINT_AUTHORITY.address,
+    TOKEN_2022_PROGRAM_ADDRESS,
+  );
 
   const createAuthorityATAInstruction =
     await getCreateAssociatedTokenInstructionAsync({
@@ -136,12 +132,8 @@ async function setup() {
 
   const signedTx = await signTransactionMessageWithSigners(tx);
 
-  console.log(
-    `Explorer ${getExplorerLink({
-      cluster: "devnet",
-      transaction: getSignatureFromTransaction(signedTx),
-    })}`
-  );
+  const txSignature = getSignatureFromTransaction(signedTx);
+  console.log("Transaction Signature:", txSignature);
 
   await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/burn-tokens.mdx
+++ b/apps/web/content/cookbook/tokens/burn-tokens.mdx
@@ -15,7 +15,8 @@ import {
   signTransactionMessageWithSigners,
   getExplorerLink,
   getSignatureFromTransaction,
-  airdropFactory
+  airdropFactory,
+  lamports
 } from "gill";
 import {
   getMintSize,

--- a/apps/web/content/cookbook/tokens/burn-tokens.mdx
+++ b/apps/web/content/cookbook/tokens/burn-tokens.mdx
@@ -7,6 +7,151 @@ You can burn tokens if you are the token account authority.
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  generateKeyPairSigner,
+  createTransaction,
+  signTransactionMessageWithSigners,
+  getExplorerLink,
+  getSignatureFromTransaction,
+} from "gill";
+import {
+  getMintSize,
+  getCreateAccountInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getInitializeMintInstruction,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  getMintToCheckedInstruction,
+  getBurnCheckedInstruction,
+} from "gill/programs";
+
+const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "localnet",
+});
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+let { mint, authorityATA } = await setup();
+
+const burnTokenIx = getBurnCheckedInstruction({
+  account: authorityATA,
+  mint: mint,
+  authority: MINT_AUTHORITY,
+  amount: 100_000_000_000n, // 100 tokens
+  decimals: 9,
+});
+
+
+const tx = createTransaction({
+  feePayer: MINT_AUTHORITY,
+  version: "legacy",
+  instructions: [burnTokenIx],
+  latestBlockhash,
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx);
+
+/*
+ * The setup function initializes the mint and associated token accounts,
+ *
+ */
+
+async function setup() {
+
+   await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+    });
+
+  const mint = await generateKeyPairSigner();
+
+  const space = BigInt(getMintSize());
+
+  const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+  // create & initialize mint account
+  const createAccountInstruction = getCreateAccountInstruction({
+    payer: MINT_AUTHORITY,
+    newAccount: mint,
+    lamports: rent,
+    space,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const initializeMintInstruction = getInitializeMintInstruction({
+    mint: mint.address,
+    decimals: 9,
+    mintAuthority: MINT_AUTHORITY.address,
+  });
+
+  // create token account
+  const [authorityATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: MINT_AUTHORITY.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const createAuthorityATAInstruction =
+    await getCreateAssociatedTokenInstructionAsync({
+      payer: MINT_AUTHORITY,
+      mint: mint.address,
+      owner: MINT_AUTHORITY.address,
+    });
+
+  // mintTo token account
+  const mintToInstruction = await getMintToCheckedInstruction({
+    mint: mint.address,
+    token: authorityATA,
+    mintAuthority: MINT_AUTHORITY,
+    amount: 1_000_000_000_000n, // 1000
+    decimals: 9,
+  });
+
+  const instructions = [
+    createAccountInstruction,
+    initializeMintInstruction,
+    createAuthorityATAInstruction,
+    mintToInstruction,
+  ];
+
+  const tx = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions,
+    latestBlockhash,
+  });
+
+  const signedTx = await signTransactionMessageWithSigners(tx);
+
+  console.log(
+    `Explorer ${getExplorerLink({
+      cluster: "devnet",
+      transaction: getSignatureFromTransaction(signedTx),
+    })}`
+  );
+
+  await sendAndConfirmTransaction(signedTx);
+
+  return {
+    mint: mint.address,
+    authorityATA,
+  };
+}
+```
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {

--- a/apps/web/content/cookbook/tokens/close-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/close-token-accounts.mdx
@@ -21,7 +21,8 @@ import {
   signTransactionMessageWithSigners,
   getExplorerLink,
   getSignatureFromTransaction,
-  airdropFactory
+  airdropFactory,
+  lamports,
 } from "gill";
 import {
   getMintSize,

--- a/apps/web/content/cookbook/tokens/close-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/close-token-accounts.mdx
@@ -15,31 +15,31 @@ situations:
 
 ```ts !! title="Gill"
 import {
+  airdropFactory,
   createSolanaClient,
-  generateKeyPairSigner,
   createTransaction,
-  signTransactionMessageWithSigners,
+  generateKeyPairSigner,
   getExplorerLink,
   getSignatureFromTransaction,
-  airdropFactory,
   lamports,
+  signTransactionMessageWithSigners,
 } from "gill";
 import {
-  getMintSize,
-  getCreateAccountInstruction,
-  TOKEN_2022_PROGRAM_ADDRESS,
-  getInitializeMintInstruction,
   getAssociatedTokenAccountAddress,
-  getCreateAssociatedTokenInstructionAsync,
-  getMintToCheckedInstruction,
-  getCloseAccountInstruction,
+  getBurnCheckedInstruction,
   getBurnInstruction,
-  getBurnCheckedInstruction
+  getCloseAccountInstruction,
+  getCreateAccountInstruction,
+  getCreateAssociatedTokenInstructionAsync,
+  getInitializeMintInstruction,
+  getMintSize,
+  getMintToCheckedInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
 } from "gill/programs";
 
 const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
   {
-    urlOrMoniker: "devnet"
+    urlOrMoniker: "localnet"
   }
 );
 
@@ -151,7 +151,6 @@ async function setup() {
   const signedTx = await signTransactionMessageWithSigners(tx);
 
   const txSignature = getSignatureFromTransaction(signedTx);
-  console.log("Transaction Signature:", txSignature);
 
   await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/close-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/close-token-accounts.mdx
@@ -48,7 +48,7 @@ const DECIMALS = 9;
 
 let { mint, authorityATA } = await setup();
 
-// Non-native account can only be closed if its balance is zero' hence why the burn token instruction
+// Non-native account can only be closed if its balance is zero hence why the burn token instruction
 const burnTokenIx = getBurnCheckedInstruction({
   account: authorityATA,
   mint: mint,

--- a/apps/web/content/cookbook/tokens/close-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/close-token-accounts.mdx
@@ -27,7 +27,7 @@ import {
   getCreateAccountInstruction,
   TOKEN_2022_PROGRAM_ADDRESS,
   getInitializeMintInstruction,
-  findAssociatedTokenPda,
+  getAssociatedTokenAccountAddress,
   getCreateAssociatedTokenInstructionAsync,
   getMintToCheckedInstruction,
   getCloseAccountInstruction,
@@ -68,12 +68,8 @@ const tx = createTransaction({
 
 const signedTx = await signTransactionMessageWithSigners(tx);
 
-console.log(
-  `Explorer ${getExplorerLink({
-    cluster: "devnet",
-    transaction: getSignatureFromTransaction(signedTx),
-  })}`
-);
+const txSignature = getSignatureFromTransaction(signedTx);
+console.log("Transaction Signature:", txSignature);
 
 await sendAndConfirmTransaction(signedTx);
 
@@ -112,11 +108,11 @@ async function setup() {
   });
 
   // create token account
-  const [authorityATA] = await findAssociatedTokenPda({
-    mint: mint.address,
-    owner: MINT_AUTHORITY.address,
-    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-  });
+    const authorityATA = await getAssociatedTokenAccountAddress(
+       mint.address,
+       MINT_AUTHORITY.address,
+      TOKEN_2022_PROGRAM_ADDRESS,
+    );
 
   const createAuthorityATAInstruction =
     await getCreateAssociatedTokenInstructionAsync({
@@ -150,12 +146,8 @@ async function setup() {
 
   const signedTx = await signTransactionMessageWithSigners(tx);
 
-  console.log(
-    `Explorer ${getExplorerLink({
-      cluster: "devnet",
-      transaction: getSignatureFromTransaction(signedTx),
-    })}`
-  );
+  const txSignature = getSignatureFromTransaction(signedTx);
+  console.log("Transaction Signature:", txSignature);
 
   await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/close-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/close-token-accounts.mdx
@@ -21,6 +21,7 @@ import {
   signTransactionMessageWithSigners,
   getExplorerLink,
   getSignatureFromTransaction,
+  airdropFactory
 } from "gill";
 import {
   getMintSize,
@@ -32,38 +33,41 @@ import {
   getMintToCheckedInstruction,
   getCloseAccountInstruction,
   getBurnInstruction,
-  getBurnCheckedInstruction,
+  getBurnCheckedInstruction
 } from "gill/programs";
 
-const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
-  urlOrMoniker: "devnet",
-});
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "devnet"
+  }
+);
 
 const MINT_AUTHORITY = await generateKeyPairSigner();
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const DECIMALS = 9;
 
 let { mint, authorityATA } = await setup();
 
+// Non-native account can only be closed if its balance is zero' hence why the burn token instruction
 const burnTokenIx = getBurnCheckedInstruction({
   account: authorityATA,
   mint: mint,
   authority: MINT_AUTHORITY,
   amount: 1000000000000n,
-  decimals: 9,
+  decimals: DECIMALS
 });
 
-// Non-native account can only be closed if its balance is zero' hence why thr butn token instruction
 const closeTokenAccountIx = getCloseAccountInstruction({
   account: authorityATA,
   destination: MINT_AUTHORITY.address,
-  owner: MINT_AUTHORITY,
+  owner: MINT_AUTHORITY
 });
 
 const tx = createTransaction({
   feePayer: MINT_AUTHORITY,
   version: "legacy",
   instructions: [burnTokenIx, closeTokenAccountIx],
-  latestBlockhash,
+  latestBlockhash
 });
 
 const signedTx = await signTransactionMessageWithSigners(tx);
@@ -75,15 +79,14 @@ await sendAndConfirmTransaction(signedTx);
 
 /*
  * The setup function initializes the mint and associated token accounts,
+ * and mints tokens to said associated token account
  *
  */
-
 async function setup() {
-
-   await airdropFactory({ rpc, rpcSubscriptions })({
-        recipientAddress: MINT_AUTHORITY.address,
-        lamports: lamports(1_000_000_000n),
-        commitment: "confirmed"
+  await airdropFactory({ rpc, rpcSubscriptions })({
+    recipientAddress: MINT_AUTHORITY.address,
+    lamports: lamports(1_000_000_000n),
+    commitment: "confirmed"
   });
 
   const mint = await generateKeyPairSigner();
@@ -98,27 +101,27 @@ async function setup() {
     newAccount: mint,
     lamports: rent,
     space,
-    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS
   });
 
   const initializeMintInstruction = getInitializeMintInstruction({
     mint: mint.address,
-    decimals: 9,
-    mintAuthority: MINT_AUTHORITY.address,
+    decimals: DECIMALS,
+    mintAuthority: MINT_AUTHORITY.address
   });
 
   // create token account
-    const authorityATA = await getAssociatedTokenAccountAddress(
-       mint.address,
-       MINT_AUTHORITY.address,
-      TOKEN_2022_PROGRAM_ADDRESS,
-    );
+  const authorityATA = await getAssociatedTokenAccountAddress(
+    mint.address,
+    MINT_AUTHORITY.address,
+    TOKEN_2022_PROGRAM_ADDRESS
+  );
 
   const createAuthorityATAInstruction =
     await getCreateAssociatedTokenInstructionAsync({
       payer: MINT_AUTHORITY,
       mint: mint.address,
-      owner: MINT_AUTHORITY.address,
+      owner: MINT_AUTHORITY.address
     });
 
   // mintTo token account
@@ -127,21 +130,21 @@ async function setup() {
     token: authorityATA,
     mintAuthority: MINT_AUTHORITY,
     amount: 1_000_000_000_000n, // 1000
-    decimals: 9,
+    decimals: DECIMALS
   });
 
   const instructions = [
     createAccountInstruction,
     initializeMintInstruction,
     createAuthorityATAInstruction,
-    mintToInstruction,
+    mintToInstruction
   ];
 
   const tx = createTransaction({
     feePayer: MINT_AUTHORITY,
     version: "legacy",
     instructions,
-    latestBlockhash,
+    latestBlockhash
   });
 
   const signedTx = await signTransactionMessageWithSigners(tx);
@@ -153,7 +156,7 @@ async function setup() {
 
   return {
     mint: mint.address,
-    authorityATA,
+    authorityATA
   };
 }
 ```

--- a/apps/web/content/cookbook/tokens/close-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/close-token-accounts.mdx
@@ -13,6 +13,159 @@ situations:
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  generateKeyPairSigner,
+  createTransaction,
+  signTransactionMessageWithSigners,
+  getExplorerLink,
+  getSignatureFromTransaction,
+} from "gill";
+import {
+  getMintSize,
+  getCreateAccountInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getInitializeMintInstruction,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  getMintToCheckedInstruction,
+  getCloseAccountInstruction,
+  getBurnInstruction,
+  getBurnCheckedInstruction,
+} from "gill/programs";
+
+const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+let { mint, authorityATA } = await setup();
+
+const burnTokenIx = getBurnCheckedInstruction({
+  account: authorityATA,
+  mint: mint,
+  authority: MINT_AUTHORITY,
+  amount: 1000000000000n,
+  decimals: 9,
+});
+
+// Non-native account can only be closed if its balance is zero' hence why thr butn token instruction
+const closeTokenAccountIx = getCloseAccountInstruction({
+  account: authorityATA,
+  destination: MINT_AUTHORITY.address,
+  owner: MINT_AUTHORITY,
+});
+
+const tx = createTransaction({
+  feePayer: MINT_AUTHORITY,
+  version: "legacy",
+  instructions: [burnTokenIx, closeTokenAccountIx],
+  latestBlockhash,
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx);
+
+/*
+ * The setup function initializes the mint and associated token accounts,
+ *
+ */
+
+async function setup() {
+
+   await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+  });
+
+  const mint = await generateKeyPairSigner();
+
+  const space = BigInt(getMintSize());
+
+  const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+  // create & initialize mint account
+  const createAccountInstruction = getCreateAccountInstruction({
+    payer: MINT_AUTHORITY,
+    newAccount: mint,
+    lamports: rent,
+    space,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const initializeMintInstruction = getInitializeMintInstruction({
+    mint: mint.address,
+    decimals: 9,
+    mintAuthority: MINT_AUTHORITY.address,
+  });
+
+  // create token account
+  const [authorityATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: MINT_AUTHORITY.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const createAuthorityATAInstruction =
+    await getCreateAssociatedTokenInstructionAsync({
+      payer: MINT_AUTHORITY,
+      mint: mint.address,
+      owner: MINT_AUTHORITY.address,
+    });
+
+  // mintTo token account
+  const mintToInstruction = await getMintToCheckedInstruction({
+    mint: mint.address,
+    token: authorityATA,
+    mintAuthority: MINT_AUTHORITY,
+    amount: 1_000_000_000_000n, // 1000
+    decimals: 9,
+  });
+
+  const instructions = [
+    createAccountInstruction,
+    initializeMintInstruction,
+    createAuthorityATAInstruction,
+    mintToInstruction,
+  ];
+
+  const tx = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions,
+    latestBlockhash,
+  });
+
+  const signedTx = await signTransactionMessageWithSigners(tx);
+
+  console.log(
+    `Explorer ${getExplorerLink({
+      cluster: "devnet",
+      transaction: getSignatureFromTransaction(signedTx),
+    })}`
+  );
+
+  await sendAndConfirmTransaction(signedTx);
+
+  return {
+    mint: mint.address,
+    authorityATA,
+  };
+}
+```
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {

--- a/apps/web/content/cookbook/tokens/get-all-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/get-all-token-accounts.mdx
@@ -163,6 +163,34 @@ async fn main() -> anyhow::Result<()> {
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import { address, createSolanaClient } from "gill";
+
+const { rpc } = createSolanaClient({
+  urlOrMoniker: "devnet"
+});
+
+let owner = address("4kg8oh3jdNtn7j2wcS7TrUua31AgbLzDVkBZgTAe44aF");
+let mint = address("6sgxNSdXgkEFVLA2YEQFnuFHU3WGafhu9WYzXAXY7yCq");
+
+let response = await rpc
+  .getTokenAccountsByOwner(owner, { mint }, { encoding: "jsonParsed" })
+  .send();
+
+response.value.forEach((accountInfo) => {
+  console.log(`pubkey: ${accountInfo.pubkey}`);
+  console.log(`mint: ${accountInfo.account.data["parsed"]["info"]["mint"]}`);
+  console.log(`owner: ${accountInfo.account.data["parsed"]["info"]["owner"]}`);
+  console.log(
+    `decimals: ${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["decimals"]}`
+  );
+  console.log(
+    `amount: ${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["amount"]}`
+  );
+  console.log("====================");
+});
+```
+
 ```ts !! title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
 

--- a/apps/web/content/cookbook/tokens/get-all-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/get-all-token-accounts.mdx
@@ -11,6 +11,38 @@ You can fetch token accounts by owner. There are two ways to do it.
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import { address, createSolanaClient } from "gill";
+import { TOKEN_PROGRAM_ADDRESS } from "gill/programs/token";
+
+const { rpc } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+let owner = address("4kg8oh3jdNtn7j2wcS7TrUua31AgbLzDVkBZgTAe44aF");
+
+let response = await rpc
+  .getTokenAccountsByOwner(
+    owner,
+    { programId: TOKEN_PROGRAM_ADDRESS },
+    { encoding: "jsonParsed" }
+  )
+  .send();
+
+response.value.forEach((accountInfo) => {
+  console.log(`pubkey:${accountInfo.pubkey}`);
+  console.log(`Mint:${accountInfo.account.data["parsed"]["info"]["mint"]}`);
+  console.log(`Owner:${accountInfo.account.data["parsed"]["info"]["owner"]}`);
+  console.log(
+    `Decimals:${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["decimals"]}`
+  );
+  console.log(
+    `Amount:${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["amount"]}`
+  );
+  console.log("=====================");
+});
+```
+
 ```ts !! title="Kit"
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
 import { address, createSolanaRpc } from "@solana/kit";

--- a/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
+++ b/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
@@ -37,6 +37,7 @@ import {
   getSignatureFromTransaction,
   lamports,
   signTransactionMessageWithSigners,
+  airdropFactory,
 } from "gill";
 import {
   getAssociatedTokenAccountAddress,
@@ -80,9 +81,9 @@ const createAtaInstruction = await getCreateAssociatedTokenInstructionAsync({
 const amountToSync = 1_000_000_000n;
 
 const transferSolInstruction = getTransferSolInstruction({
-    source: feePayer,
-    destination: associatedTokenAddress,
-    amount: amountToSync,
+  source: feePayer,
+  destination: associatedTokenAddress,
+  amount: amountToSync,
 });
 
 const syncNativeInstruction = getSyncNativeInstruction({
@@ -373,6 +374,7 @@ const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
 const SENDER = await generateKeyPairSigner();
 const SENDER_TEMPORARY_TOKEN_ACCOUNT = await generateKeyPairSigner();
 const RECIPIENT = await generateKeyPairSigner();
+const DECIMALS = 9;
 
 // Native mint (Wrapped SOL) address
 const NATIVE_MINT = address("So11111111111111111111111111111111111111112");
@@ -429,7 +431,7 @@ const transferTokenInstruction = getTransferCheckedInstruction({
   destination: recipientATA,
   authority: SENDER,
   amount: amount, // 1 WSOL
-  decimals: 9
+  decimals: DECIMALS
 });
 
 // close temp account

--- a/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
+++ b/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
@@ -39,11 +39,11 @@ import {
   signTransactionMessageWithSigners,
 } from "gill";
 import {
-  findAssociatedTokenPda,
+  getAssociatedTokenAccountAddress,
   getCreateAssociatedTokenInstructionAsync,
+  getTransferSolInstruction,
   TOKEN_PROGRAM_ADDRESS,
-} from "gill/programs/token";
-import {getTransferSolInstruction} from "gill/programs"
+} from "gill/programs";
 import { getSyncNativeInstruction } from "@solana-program/token";
 
 const { rpc, rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient(
@@ -58,12 +58,12 @@ const feePayer = await generateKeyPairSigner();
 // Native mint (Wrapped SOL) address
 const NATIVE_MINT = address("So11111111111111111111111111111111111111112");
 
-// Use findAssociatedTokenPda to derive the ATA address for WSOL
-const [associatedTokenAddress] = await findAssociatedTokenPda({
-  mint: NATIVE_MINT,
-  owner: feePayer.address,
-  tokenProgram: TOKEN_PROGRAM_ADDRESS,
-});
+// Use getAssociatedTokenAccountAddress to derive the ATA address for WSOL
+const associatedTokenAddress = await getAssociatedTokenAccountAddress(
+  NATIVE_MINT,
+  feePayer.address,
+  TOKEN_PROGRAM_ADDRESS
+);
 
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 await requestAirdrop()
@@ -104,12 +104,8 @@ const tx = createTransaction({
 
 const signedTx = await signTransactionMessageWithSigners(tx);
 
-console.log(`Explorer ${
-    getExplorerLink({
-        cluster:'devnet',
-        transaction:getSignatureFromTransaction(signedTx)
-    })
-}`);
+const txSignature = getSignatureFromTransaction(signedTx);
+console.log("Transaction Signature:", txSignature);
 
 await sendAndConfirmTransaction(signedTx)
 
@@ -361,11 +357,11 @@ import {
   lamports,
 } from "gill";
 import {
-  findAssociatedTokenPda,
+  getAssociatedTokenAccountAddress,
   getTokenSize,
   TOKEN_PROGRAM_ADDRESS,
-} from "gill/programs/token";
-import { getCreateAccountInstruction } from "gill/programs";
+  getCreateAccountInstruction
+} from "gill/programs";
 import { getCloseAccountInstruction, getCreateAssociatedTokenInstructionAsync, getInitializeAccountInstruction, getSyncNativeInstruction, getTransferCheckedInstruction } from "@solana-program/token";
 
 const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
@@ -381,12 +377,13 @@ const RECIPIENT = await generateKeyPairSigner();
 // Native mint (Wrapped SOL) address
 const NATIVE_MINT = address("So11111111111111111111111111111111111111112");
 
-// Use findAssociatedTokenPda to derive the ATA address for WSOL
-const [recipientATA] = await findAssociatedTokenPda({
-  mint: NATIVE_MINT,
-  owner: RECIPIENT.address,
-  tokenProgram: TOKEN_PROGRAM_ADDRESS,
-});
+// Use getAssociatedTokenAccountAddress to derive the ATA address for WSOL
+const associatedTokenAddress = await getAssociatedTokenAccountAddress(
+  NATIVE_MINT,
+  RECIPIENT.address,
+  TOKEN_PROGRAM_ADDRESS
+);
+
 
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
@@ -459,12 +456,8 @@ const tx = createTransaction({
 
 const signedTx = await signTransactionMessageWithSigners(tx);
 
-console.log(
-  `Explorer ${getExplorerLink({
-    cluster: "devnet",
-    transaction: getSignatureFromTransaction(signedTx),
-  })}`
-);
+const txSignature = getSignatureFromTransaction(signedTx);
+console.log("Transaction Signature:", txSignature);
 
 await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
+++ b/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
@@ -30,6 +30,7 @@ There are two ways to add balance for Wrapped SOL
 ```ts !! title="Gill"
 import {
   address,
+  airdropFactory,
   createSolanaClient,
   createTransaction,
   generateKeyPairSigner,
@@ -37,7 +38,6 @@ import {
   getSignatureFromTransaction,
   lamports,
   signTransactionMessageWithSigners,
-  airdropFactory,
 } from "gill";
 import {
   getAssociatedTokenAccountAddress,
@@ -49,7 +49,7 @@ import { getSyncNativeInstruction } from "@solana-program/token";
 
 const { rpc, rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient(
   {
-    urlOrMoniker: "devnet",
+    urlOrMoniker: "localnet",
   }
 );
 
@@ -348,13 +348,13 @@ async fn main() -> anyhow::Result<()> {
 ```ts !! title ="Gill"
 import {
   address,
+  airdropFactory,
   createSolanaClient,
   createTransaction,
   getExplorerLink,
   getSignatureFromTransaction,
   generateKeyPairSigner,
   signTransactionMessageWithSigners,
-  airdropFactory,
   lamports,
 } from "gill";
 import {
@@ -366,9 +366,8 @@ import {
 import { getCloseAccountInstruction, getCreateAssociatedTokenInstructionAsync, getInitializeAccountInstruction, getSyncNativeInstruction, getTransferCheckedInstruction } from "@solana-program/token";
 
 const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
-  urlOrMoniker: "devnet",
+  urlOrMoniker: "localnet",
 });
-
 
 /* constants */
 const SENDER = await generateKeyPairSigner();

--- a/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
+++ b/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
@@ -345,7 +345,7 @@ async fn main() -> anyhow::Result<()> {
 
 <CodeTabs storage="cookbook">
 
-```ts !! title = "Gill"
+```ts !! title ="Gill"
 import {
   address,
   createSolanaClient,

--- a/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
+++ b/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
@@ -27,6 +27,101 @@ There are two ways to add balance for Wrapped SOL
 
 <CodeTabs storage="cookbook">
 
+```ts !! title="Gill"
+import {
+  address,
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getExplorerLink,
+  getSignatureFromTransaction,
+  lamports,
+  signTransactionMessageWithSigners,
+} from "gill";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  TOKEN_PROGRAM_ADDRESS,
+} from "gill/programs/token";
+import {getTransferSolInstruction} from "gill/programs"
+import { getSyncNativeInstruction } from "@solana-program/token";
+
+const { rpc, rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "devnet",
+  }
+);
+
+// Generate key pairs for fee payer
+const feePayer = await generateKeyPairSigner();
+
+// Native mint (Wrapped SOL) address
+const NATIVE_MINT = address("So11111111111111111111111111111111111111112");
+
+// Use findAssociatedTokenPda to derive the ATA address for WSOL
+const [associatedTokenAddress] = await findAssociatedTokenPda({
+  mint: NATIVE_MINT,
+  owner: feePayer.address,
+  tokenProgram: TOKEN_PROGRAM_ADDRESS,
+});
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+await requestAirdrop()
+
+// Create instructions to create the WSOL associated token account
+const createAtaInstruction = await getCreateAssociatedTokenInstructionAsync({
+  payer: feePayer,
+  mint: NATIVE_MINT,
+  owner: feePayer.address,
+  tokenProgram:TOKEN_PROGRAM_ADDRESS
+});
+
+// Amount to wrap (1 SOL = 1,000,000,000 lamports)
+const amountToSync = 1_000_000_000n;
+
+const transferSolInstruction = getTransferSolInstruction({
+    source: feePayer,
+    destination: associatedTokenAddress,
+    amount: amountToSync,
+});
+
+const syncNativeInstruction = getSyncNativeInstruction({
+  account: associatedTokenAddress,
+});
+
+const instructions = [
+  createAtaInstruction,
+  transferSolInstruction,
+  syncNativeInstruction,
+];
+
+const tx = createTransaction({
+  feePayer,
+  version: "legacy",
+  instructions,
+  latestBlockhash,
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(`Explorer ${
+    getExplorerLink({
+        cluster:'devnet',
+        transaction:getSignatureFromTransaction(signedTx)
+    })
+}`);
+
+await sendAndConfirmTransaction(signedTx)
+
+async function  requestAirdrop () {
+  await  airdropFactory ({ rpc, rpcSubscriptions })({
+    recipientAddress:  feePayer.address,
+    lamports:  lamports ( 5_000_000_000 n ),  // 5 SOL
+    commitment:  "confirmed"
+  });
+}
+```
+
 ```ts !! title="Kit"
 import { getTransferSolInstruction } from "@solana-program/system";
 import {
@@ -252,6 +347,135 @@ async fn main() -> anyhow::Result<()> {
 ### 2. By Token Transfer
 
 <CodeTabs storage="cookbook">
+
+```ts !! title = "Gill"
+import {
+  address,
+  createSolanaClient,
+  createTransaction,
+  getExplorerLink,
+  getSignatureFromTransaction,
+  generateKeyPairSigner,
+  signTransactionMessageWithSigners,
+  airdropFactory,
+  lamports,
+} from "gill";
+import {
+  findAssociatedTokenPda,
+  getTokenSize,
+  TOKEN_PROGRAM_ADDRESS,
+} from "gill/programs/token";
+import { getCreateAccountInstruction } from "gill/programs";
+import { getCloseAccountInstruction, getCreateAssociatedTokenInstructionAsync, getInitializeAccountInstruction, getSyncNativeInstruction, getTransferCheckedInstruction } from "@solana-program/token";
+
+const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+
+/* constants */
+const SENDER = await generateKeyPairSigner();
+const SENDER_TEMPORARY_TOKEN_ACCOUNT = await generateKeyPairSigner();
+const RECIPIENT = await generateKeyPairSigner();
+
+// Native mint (Wrapped SOL) address
+const NATIVE_MINT = address("So11111111111111111111111111111111111111112");
+
+// Use findAssociatedTokenPda to derive the ATA address for WSOL
+const [recipientATA] = await findAssociatedTokenPda({
+  mint: NATIVE_MINT,
+  owner: RECIPIENT.address,
+  tokenProgram: TOKEN_PROGRAM_ADDRESS,
+});
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+await requestAirdrop();
+
+// Amount to wrap (1 SOL = 1,000,000,000 lamports)
+const amount = 1_000_000_000n;
+
+const tokenAccountLen = getTokenSize();
+const tokenAccountRent = await rpc
+  .getMinimumBalanceForRentExemption(BigInt(tokenAccountLen))
+  .send();
+
+// create temporary token account
+// adds extra transfer amount lamports to token account
+const createAccountInstruction = getCreateAccountInstruction({
+  payer: SENDER,
+  newAccount: SENDER_TEMPORARY_TOKEN_ACCOUNT,
+  lamports: tokenAccountRent + amount,
+  programAddress: TOKEN_PROGRAM_ADDRESS,
+  space: tokenAccountLen
+});
+
+// initialize temporary token account
+const initAccountInstruction = getInitializeAccountInstruction({
+  account: SENDER_TEMPORARY_TOKEN_ACCOUNT.address,
+  mint: NATIVE_MINT,
+  owner: SENDER.address,
+});
+
+// create recipient wrapped sol token account
+const createRecipientATAInstruction =
+  await getCreateAssociatedTokenInstructionAsync({
+    payer: SENDER,
+    mint: NATIVE_MINT,
+    owner: RECIPIENT.address,
+  });
+
+// transfer WSOL
+const transferTokenInstruction = getTransferCheckedInstruction({
+  source: SENDER_TEMPORARY_TOKEN_ACCOUNT.address,
+  mint: NATIVE_MINT,
+  destination: recipientATA,
+  authority: SENDER,
+  amount: amount, // 1 WSOL
+  decimals: 9
+});
+
+// close temp account
+const closeTokenAccountInstruction = getCloseAccountInstruction({
+  account: SENDER_TEMPORARY_TOKEN_ACCOUNT.address,
+  destination: SENDER.address,
+  owner: SENDER
+});
+
+const instructions = [
+  createAccountInstruction,
+  initAccountInstruction,
+  createRecipientATAInstruction,
+  transferTokenInstruction,
+  closeTokenAccountInstruction
+];
+
+const tx = createTransaction({
+  feePayer:SENDER,
+  version: "legacy",
+  instructions,
+  latestBlockhash,
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx);
+
+async function requestAirdrop() {
+  await airdropFactory({ rpc, rpcSubscriptions })({
+    recipientAddress: SENDER.address,
+    lamports: lamports(5_000_000_000n), // 5 SOL
+    commitment: "confirmed"
+  });
+}
+```
 
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";

--- a/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
@@ -17,6 +17,7 @@ import {
   getExplorerLink,
   getSignatureFromTransaction,
   signTransactionMessageWithSigners,
+  airdropFactory
 } from "gill";
 import {
   getAssociatedTokenAccountAddress,
@@ -26,29 +27,32 @@ import {
   getMintSize,
   getMintToCheckedInstruction,
   getRevokeInstruction,
-  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_2022_PROGRAM_ADDRESS
 } from "gill/programs";
 
-const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
-  urlOrMoniker: "devnet",
-});
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "devnet"
+  }
+);
 
 const MINT_AUTHORITY = await generateKeyPairSigner();
 
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const DECIMALS = 9;
 
 let { authorityATA } = await setup();
 
 const revokeDelegateIx = getRevokeInstruction({
   source: authorityATA,
-  owner: MINT_AUTHORITY,
+  owner: MINT_AUTHORITY
 });
 
 const tx = createTransaction({
   feePayer: MINT_AUTHORITY,
   version: "legacy",
   instructions: [revokeDelegateIx],
-  latestBlockhash,
+  latestBlockhash
 });
 
 const signedTx = await signTransactionMessageWithSigners(tx);
@@ -60,15 +64,14 @@ await sendAndConfirmTransaction(signedTx);
 
 /*
  * The setup function initializes the mint and associated token accounts,
+ * and mints tokens to said associated token account
  *
  */
-
 async function setup() {
-
   await airdropFactory({ rpc, rpcSubscriptions })({
-        recipientAddress: MINT_AUTHORITY.address,
-        lamports: lamports(1_000_000_000n),
-        commitment: "confirmed"
+    recipientAddress: MINT_AUTHORITY.address,
+    lamports: lamports(1_000_000_000n),
+    commitment: "confirmed"
   });
 
   const mint = await generateKeyPairSigner();
@@ -83,27 +86,27 @@ async function setup() {
     newAccount: mint,
     lamports: rent,
     space,
-    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS
   });
 
   const initializeMintInstruction = getInitializeMintInstruction({
     mint: mint.address,
-    decimals: 9,
-    mintAuthority: MINT_AUTHORITY.address,
+    decimals: DECIMALS,
+    mintAuthority: MINT_AUTHORITY.address
   });
 
   // create token account
-    const authorityATA = await getAssociatedTokenAccountAddress(
-       mint.address,
-       MINT_AUTHORITY.address,
-      TOKEN_2022_PROGRAM_ADDRESS,
-    );
+  const authorityATA = await getAssociatedTokenAccountAddress(
+    mint.address,
+    MINT_AUTHORITY.address,
+    TOKEN_2022_PROGRAM_ADDRESS
+  );
 
   const createAuthorityATAInstruction =
     await getCreateAssociatedTokenInstructionAsync({
       payer: MINT_AUTHORITY,
       mint: mint.address,
-      owner: MINT_AUTHORITY.address,
+      owner: MINT_AUTHORITY.address
     });
 
   // mintTo token account
@@ -112,21 +115,21 @@ async function setup() {
     token: authorityATA,
     mintAuthority: MINT_AUTHORITY,
     amount: 1_000_000_000_000n, // 1000
-    decimals: 9,
+    decimals: DECIMALS
   });
 
   const instructions = [
     createAccountInstruction,
     initializeMintInstruction,
     createAuthorityATAInstruction,
-    mintToInstruction,
+    mintToInstruction
   ];
 
   const tx = createTransaction({
     feePayer: MINT_AUTHORITY,
     version: "legacy",
     instructions,
-    latestBlockhash,
+    latestBlockhash
   });
 
   const signedTx = await signTransactionMessageWithSigners(tx);
@@ -138,7 +141,7 @@ async function setup() {
 
   return {
     mint: mint.address,
-    authorityATA,
+    authorityATA
   };
 }
 ```

--- a/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
@@ -11,14 +11,14 @@ Revoke will set delegate to null and set delegated amount to 0.
 
 ```ts !! title="Gill"
 import {
+  airdropFactory,
   createSolanaClient,
   createTransaction,
   generateKeyPairSigner,
   getExplorerLink,
   getSignatureFromTransaction,
+  lamports,
   signTransactionMessageWithSigners,
-  airdropFactory,
-  lamports
 } from "gill";
 import {
   getAssociatedTokenAccountAddress,
@@ -33,7 +33,7 @@ import {
 
 const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
   {
-    urlOrMoniker: "devnet"
+    urlOrMoniker: "localnet"
   }
 );
 
@@ -136,7 +136,6 @@ async function setup() {
   const signedTx = await signTransactionMessageWithSigners(tx);
 
   const txSignature = getSignatureFromTransaction(signedTx);
-  console.log("Transaction Signature:", txSignature);
 
   await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
@@ -17,7 +17,8 @@ import {
   getExplorerLink,
   getSignatureFromTransaction,
   signTransactionMessageWithSigners,
-  airdropFactory
+  airdropFactory,
+  lamports
 } from "gill";
 import {
   getAssociatedTokenAccountAddress,

--- a/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
@@ -19,7 +19,7 @@ import {
   signTransactionMessageWithSigners,
 } from "gill";
 import {
-  findAssociatedTokenPda,
+  getAssociatedTokenAccountAddress,
   getCreateAccountInstruction,
   getCreateAssociatedTokenInstructionAsync,
   getInitializeMintInstruction,
@@ -53,12 +53,8 @@ const tx = createTransaction({
 
 const signedTx = await signTransactionMessageWithSigners(tx);
 
-console.log(
-  `Explorer ${getExplorerLink({
-    cluster: "devnet",
-    transaction: getSignatureFromTransaction(signedTx),
-  })}`
-);
+const txSignature = getSignatureFromTransaction(signedTx);
+console.log("Transaction Signature:", txSignature);
 
 await sendAndConfirmTransaction(signedTx);
 
@@ -97,11 +93,11 @@ async function setup() {
   });
 
   // create token account
-  const [authorityATA] = await findAssociatedTokenPda({
-    mint: mint.address,
-    owner: MINT_AUTHORITY.address,
-    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-  });
+    const authorityATA = await getAssociatedTokenAccountAddress(
+       mint.address,
+       MINT_AUTHORITY.address,
+      TOKEN_2022_PROGRAM_ADDRESS,
+    );
 
   const createAuthorityATAInstruction =
     await getCreateAssociatedTokenInstructionAsync({
@@ -135,12 +131,8 @@ async function setup() {
 
   const signedTx = await signTransactionMessageWithSigners(tx);
 
-  console.log(
-    `Explorer ${getExplorerLink({
-      cluster: "devnet",
-      transaction: getSignatureFromTransaction(signedTx),
-    })}`
-  );
+  const txSignature = getSignatureFromTransaction(signedTx);
+  console.log("Transaction Signature:", txSignature);
 
   await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
@@ -9,6 +9,148 @@ Revoke will set delegate to null and set delegated amount to 0.
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getExplorerLink,
+  getSignatureFromTransaction,
+  signTransactionMessageWithSigners,
+} from "gill";
+import {
+  findAssociatedTokenPda,
+  getCreateAccountInstruction,
+  getCreateAssociatedTokenInstructionAsync,
+  getInitializeMintInstruction,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getRevokeInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+} from "gill/programs";
+
+const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+let { authorityATA } = await setup();
+
+const revokeDelegateIx = getRevokeInstruction({
+  source: authorityATA,
+  owner: MINT_AUTHORITY,
+});
+
+const tx = createTransaction({
+  feePayer: MINT_AUTHORITY,
+  version: "legacy",
+  instructions: [revokeDelegateIx],
+  latestBlockhash,
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx);
+
+/*
+ * The setup function initializes the mint and associated token accounts,
+ *
+ */
+
+async function setup() {
+
+  await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+  });
+
+  const mint = await generateKeyPairSigner();
+
+  const space = BigInt(getMintSize());
+
+  const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+  // create & initialize mint account
+  const createAccountInstruction = getCreateAccountInstruction({
+    payer: MINT_AUTHORITY,
+    newAccount: mint,
+    lamports: rent,
+    space,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const initializeMintInstruction = getInitializeMintInstruction({
+    mint: mint.address,
+    decimals: 9,
+    mintAuthority: MINT_AUTHORITY.address,
+  });
+
+  // create token account
+  const [authorityATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: MINT_AUTHORITY.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const createAuthorityATAInstruction =
+    await getCreateAssociatedTokenInstructionAsync({
+      payer: MINT_AUTHORITY,
+      mint: mint.address,
+      owner: MINT_AUTHORITY.address,
+    });
+
+  // mintTo token account
+  const mintToInstruction = await getMintToCheckedInstruction({
+    mint: mint.address,
+    token: authorityATA,
+    mintAuthority: MINT_AUTHORITY,
+    amount: 1_000_000_000_000n, // 1000
+    decimals: 9,
+  });
+
+  const instructions = [
+    createAccountInstruction,
+    initializeMintInstruction,
+    createAuthorityATAInstruction,
+    mintToInstruction,
+  ];
+
+  const tx = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions,
+    latestBlockhash,
+  });
+
+  const signedTx = await signTransactionMessageWithSigners(tx);
+
+  console.log(
+    `Explorer ${getExplorerLink({
+      cluster: "devnet",
+      transaction: getSignatureFromTransaction(signedTx),
+    })}`
+  );
+
+  await sendAndConfirmTransaction(signedTx);
+
+  return {
+    mint: mint.address,
+    authorityATA,
+  };
+}
+```
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {

--- a/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
+++ b/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
@@ -22,6 +22,7 @@ import {
   getExplorerLink,
   getSignatureFromTransaction,
   signTransactionMessageWithSigners,
+  airdropFactory
 } from "gill";
 import {
   getMintSize,
@@ -32,16 +33,19 @@ import {
   getCreateAssociatedTokenInstructionAsync,
   getMintToCheckedInstruction,
   AuthorityType,
-  getSetAuthorityInstruction,
+  getSetAuthorityInstruction
 } from "gill/programs";
 
-const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
-  urlOrMoniker: "devnet",
-});
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "devnet"
+  }
+);
 
 const MINT_AUTHORITY = await generateKeyPairSigner();
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 const NEW_AUTHORITY = await generateKeyPairSigner();
+const DECIMALS = 9;
 
 const { mint } = await setup();
 
@@ -50,7 +54,7 @@ const setMintAuthorityIx = getSetAuthorityInstruction({
   owned: mint,
   owner: MINT_AUTHORITY,
   authorityType: AuthorityType.MintTokens,
-  newAuthority: NEW_AUTHORITY.address,
+  newAuthority: NEW_AUTHORITY.address
 });
 
 // 2. Change Freeze Authority
@@ -58,7 +62,7 @@ const setFreezeAuthorityIx = getSetAuthorityInstruction({
   owned: mint,
   owner: MINT_AUTHORITY,
   authorityType: AuthorityType.FreezeAccount,
-  newAuthority: NEW_AUTHORITY.address,
+  newAuthority: NEW_AUTHORITY.address
 });
 
 // Example of revoking authority (setting to null)
@@ -66,20 +70,20 @@ const revokeMintAuthorityIx = getSetAuthorityInstruction({
   owned: mint,
   owner: NEW_AUTHORITY,
   authorityType: AuthorityType.MintTokens,
-  newAuthority: null,
+  newAuthority: null
 });
 
 const instructions = [
   setMintAuthorityIx,
   setFreezeAuthorityIx,
-  revokeMintAuthorityIx,
+  revokeMintAuthorityIx
 ];
 
 const tx = createTransaction({
-    feePayer:MINT_AUTHORITY,
-    version:'legacy',
-    instructions,
-    latestBlockhash
+  feePayer: MINT_AUTHORITY,
+  version: "legacy",
+  instructions,
+  latestBlockhash
 });
 
 const signedTx = await signTransactionMessageWithSigners(tx);
@@ -87,19 +91,18 @@ const signedTx = await signTransactionMessageWithSigners(tx);
 const txSignature = getSignatureFromTransaction(signedTx);
 console.log("Transaction Signature:", txSignature);
 
-await sendAndConfirmTransaction(signedTx)
-
+await sendAndConfirmTransaction(signedTx);
 
 /*
  * The setup function initializes the mint and associated token accounts,
+ * and mints tokens to said associated token account
  *
  */
 async function setup() {
-
   await airdropFactory({ rpc, rpcSubscriptions })({
-        recipientAddress: MINT_AUTHORITY.address,
-        lamports: lamports(1_000_000_000n),
-        commitment: "confirmed"
+    recipientAddress: MINT_AUTHORITY.address,
+    lamports: lamports(1_000_000_000n),
+    commitment: "confirmed"
   });
 
   const mint = await generateKeyPairSigner();
@@ -114,14 +117,14 @@ async function setup() {
     newAccount: mint,
     lamports: rent,
     space,
-    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS
   });
 
   const initializeMintInstruction = getInitializeMintInstruction({
     mint: mint.address,
-    decimals: 9,
+    decimals: DECIMALS,
     mintAuthority: MINT_AUTHORITY.address,
-    freezeAuthority:MINT_AUTHORITY.address
+    freezeAuthority: MINT_AUTHORITY.address
   });
 
   // create token account
@@ -135,7 +138,7 @@ async function setup() {
     await getCreateAssociatedTokenInstructionAsync({
       payer: MINT_AUTHORITY,
       mint: mint.address,
-      owner: MINT_AUTHORITY.address,
+      owner: MINT_AUTHORITY.address
     });
 
   // mintTo token account
@@ -144,21 +147,21 @@ async function setup() {
     token: authorityATA,
     mintAuthority: MINT_AUTHORITY,
     amount: 1_000_000_000_000n, // 1000
-    decimals: 9,
+    decimals: DECIMALS
   });
 
   const instructions = [
     createAccountInstruction,
     initializeMintInstruction,
     createAuthorityATAInstruction,
-    mintToInstruction,
+    mintToInstruction
   ];
 
   const tx = createTransaction({
     feePayer: MINT_AUTHORITY,
     version: "legacy",
     instructions,
-    latestBlockhash,
+    latestBlockhash
   });
 
   const signedTx = await signTransactionMessageWithSigners(tx);
@@ -170,7 +173,7 @@ async function setup() {
 
   return {
     mint: mint.address,
-    authorityATA,
+    authorityATA
   };
 }
 ```

--- a/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
+++ b/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
@@ -22,7 +22,8 @@ import {
   getExplorerLink,
   getSignatureFromTransaction,
   signTransactionMessageWithSigners,
-  airdropFactory
+  airdropFactory,
+  lamports
 } from "gill";
 import {
   getMintSize,

--- a/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
+++ b/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
@@ -27,7 +27,6 @@ import {
 } from "gill";
 import {
   AuthorityType,
-  findAssociatedTokenPda,
   getAssociatedTokenAccountAddress,
   getCreateAccountInstruction,
   getCreateAssociatedTokenInstructionAsync,

--- a/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
+++ b/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
@@ -84,12 +84,8 @@ const tx = createTransaction({
 
 const signedTx = await signTransactionMessageWithSigners(tx);
 
-console.log(
-  `Explorer ${getExplorerLink({
-    cluster: "devnet",
-    transaction: getSignatureFromTransaction(signedTx),
-  })}`
-);
+const txSignature = getSignatureFromTransaction(signedTx);
+console.log("Transaction Signature:", txSignature);
 
 await sendAndConfirmTransaction(signedTx)
 
@@ -129,11 +125,11 @@ async function setup() {
   });
 
   // create token account
-  const [authorityATA] = await findAssociatedTokenPda({
-    mint: mint.address,
-    owner: MINT_AUTHORITY.address,
-    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
-  });
+  const authorityATA = await getAssociatedTokenAccountAddress(
+    mint.address,
+    MINT_AUTHORITY.address,
+    TOKEN_2022_PROGRAM_ADDRESS
+  );
 
   const createAuthorityATAInstruction =
     await getCreateAssociatedTokenInstructionAsync({
@@ -167,12 +163,8 @@ async function setup() {
 
   const signedTx = await signTransactionMessageWithSigners(tx);
 
-  console.log(
-    `Explorer ${getExplorerLink({
-      cluster: "devnet",
-      transaction: getSignatureFromTransaction(signedTx),
-    })}`
-  );
+  const txSignature = getSignatureFromTransaction(signedTx);
+  console.log("Transaction Signature:", txSignature);
 
   await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
+++ b/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
@@ -16,30 +16,31 @@ You can set/update authority. There are 4 types:
 
 ```ts !! title="Gill"
 import {
+  airdropFactory,
   createSolanaClient,
   createTransaction,
   generateKeyPairSigner,
   getExplorerLink,
   getSignatureFromTransaction,
+  lamports,
   signTransactionMessageWithSigners,
-  airdropFactory,
-  lamports
 } from "gill";
 import {
-  getMintSize,
-  getCreateAccountInstruction,
-  TOKEN_2022_PROGRAM_ADDRESS,
-  getInitializeMintInstruction,
-  findAssociatedTokenPda,
-  getCreateAssociatedTokenInstructionAsync,
-  getMintToCheckedInstruction,
   AuthorityType,
-  getSetAuthorityInstruction
+  findAssociatedTokenPda,
+  getAssociatedTokenAccountAddress,
+  getCreateAccountInstruction,
+  getCreateAssociatedTokenInstructionAsync,
+  getInitializeMintInstruction,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getSetAuthorityInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
 } from "gill/programs";
 
 const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
   {
-    urlOrMoniker: "devnet"
+    urlOrMoniker: "localnet"
   }
 );
 
@@ -168,7 +169,6 @@ async function setup() {
   const signedTx = await signTransactionMessageWithSigners(tx);
 
   const txSignature = getSignatureFromTransaction(signedTx);
-  console.log("Transaction Signature:", txSignature);
 
   await sendAndConfirmTransaction(signedTx);
 

--- a/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
+++ b/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
@@ -14,6 +14,175 @@ You can set/update authority. There are 4 types:
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getExplorerLink,
+  getSignatureFromTransaction,
+  signTransactionMessageWithSigners,
+} from "gill";
+import {
+  getMintSize,
+  getCreateAccountInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getInitializeMintInstruction,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  getMintToCheckedInstruction,
+  AuthorityType,
+  getSetAuthorityInstruction,
+} from "gill/programs";
+
+const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const NEW_AUTHORITY = await generateKeyPairSigner();
+
+const { mint } = await setup();
+
+// 1. Change Mint Authority (MintTokens)
+const setMintAuthorityIx = getSetAuthorityInstruction({
+  owned: mint,
+  owner: MINT_AUTHORITY,
+  authorityType: AuthorityType.MintTokens,
+  newAuthority: NEW_AUTHORITY.address,
+});
+
+// 2. Change Freeze Authority
+const setFreezeAuthorityIx = getSetAuthorityInstruction({
+  owned: mint,
+  owner: MINT_AUTHORITY,
+  authorityType: AuthorityType.FreezeAccount,
+  newAuthority: NEW_AUTHORITY.address,
+});
+
+// Example of revoking authority (setting to null)
+const revokeMintAuthorityIx = getSetAuthorityInstruction({
+  owned: mint,
+  owner: NEW_AUTHORITY,
+  authorityType: AuthorityType.MintTokens,
+  newAuthority: null,
+});
+
+const instructions = [
+  setMintAuthorityIx,
+  setFreezeAuthorityIx,
+  revokeMintAuthorityIx,
+];
+
+const tx = createTransaction({
+    feePayer:MINT_AUTHORITY,
+    version:'legacy',
+    instructions,
+    latestBlockhash
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx)
+
+
+/*
+ * The setup function initializes the mint and associated token accounts,
+ *
+ */
+async function setup() {
+
+  await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+  });
+
+  const mint = await generateKeyPairSigner();
+
+  const space = BigInt(getMintSize());
+
+  const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+  // create & initialize mint account
+  const createAccountInstruction = getCreateAccountInstruction({
+    payer: MINT_AUTHORITY,
+    newAccount: mint,
+    lamports: rent,
+    space,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const initializeMintInstruction = getInitializeMintInstruction({
+    mint: mint.address,
+    decimals: 9,
+    mintAuthority: MINT_AUTHORITY.address,
+    freezeAuthority:MINT_AUTHORITY.address
+  });
+
+  // create token account
+  const [authorityATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: MINT_AUTHORITY.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const createAuthorityATAInstruction =
+    await getCreateAssociatedTokenInstructionAsync({
+      payer: MINT_AUTHORITY,
+      mint: mint.address,
+      owner: MINT_AUTHORITY.address,
+    });
+
+  // mintTo token account
+  const mintToInstruction = await getMintToCheckedInstruction({
+    mint: mint.address,
+    token: authorityATA,
+    mintAuthority: MINT_AUTHORITY,
+    amount: 1_000_000_000_000n, // 1000
+    decimals: 9,
+  });
+
+  const instructions = [
+    createAccountInstruction,
+    initializeMintInstruction,
+    createAuthorityATAInstruction,
+    mintToInstruction,
+  ];
+
+  const tx = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions,
+    latestBlockhash,
+  });
+
+  const signedTx = await signTransactionMessageWithSigners(tx);
+
+  console.log(
+    `Explorer ${getExplorerLink({
+      cluster: "devnet",
+      transaction: getSignatureFromTransaction(signedTx),
+    })}`
+  );
+
+  await sendAndConfirmTransaction(signedTx);
+
+  return {
+    mint: mint.address,
+    authorityATA,
+  };
+}
+```
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {


### PR DESCRIPTION
### Problem
The Solana cookbook was lacking on gill token examples for burning tokens,closing token accounts,setting and revoking delegate etc


### Summary of Changes
Add Gill to Solana Cookbook for token examples for burning tokens,closing token accounts,setting and revoking delegate on token accounts,how to use wrapped sol by transfer and balance,get all token accounts authority

